### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ Scripts and Contexts
 	i.q 			initial state (used by reset)
 	j.q             javascript interaction utilities
 	x.q             hypertree parameters
-	a.q             auxilliary functions
+	a.q             auxiliary functions
 
 	h.q             standalone hypertree process
 


### PR DESCRIPTION
stevanapter, I've corrected a typographical error in the documentation of the [hypertree](https://github.com/stevanapter/hypertree) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
